### PR TITLE
Add test for Windows 8.1

### DIFF
--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -26,6 +26,7 @@ public static class Constants
     };
 
     public const string Windows8 = "Windows NT 6.2";
+    public const string Windows81 = "Windows NT 6.3";
 
     public const string Version452Detected = "4.5.2";
     public const string Version45Detected = "4.5";

--- a/SmallestDotNetLib/Helpers.cs
+++ b/SmallestDotNetLib/Helpers.cs
@@ -201,7 +201,7 @@ public class Helpers
     /// <returns></returns>
     public static bool HasWindows8(String UserAgent)
     {
-        return UserAgent.Contains(Constants.Windows8);
+        return UserAgent.Contains(Constants.Windows8) || UserAgent.Contains(Constants.Windows81);
     }
 
     /// <summary>

--- a/SmallestDotNetLib/Helpers.cs
+++ b/SmallestDotNetLib/Helpers.cs
@@ -15,7 +15,13 @@ public class Helpers
         string netInfoString = "";
 
 
-        //We should check this first since we don't need to check .NET versions if they can't have .NET versions
+        // We should check this first since we don't need to check .NET versions if they can't have .NET versions
+        // Check for windows phone first as it may contain 'Mac' in User Agent
+        if (UserAgent.Contains("Windows Phone"))
+        {
+            netInfoString = "It looks like you're running a Windows Phone, awesome! There's no .NET Framework download for the Windows phone, but you might check out <a href=\"https://dev.windows.com/\"/>the Windows Dev Center</a> or <a href=\"http://www.windowsphone.com/store/\"/>the Windows Phone Store</a>";
+            return netInfoString;
+        }
         if (UserAgent.Contains("Mac"))
         {
             netInfoString = "It looks like you're running a Mac or an iPhone. There's no .NET Framework download from Microsoft for the Mac, but you might check out <a href=\"http://www.go-mono.com/mono-downloads/download.html\">Mono</a>, which is an Open Source platform that can run .NET code on a Mac. For your iPhone, check out <a href=\"http://xamarin.com/monotouch\">MonoTouch</a> and write .NET apps for iOS!";

--- a/SmallestDotNetLib/OperatingSystemSupport.cs
+++ b/SmallestDotNetLib/OperatingSystemSupport.cs
@@ -12,6 +12,7 @@
 
     public class OperatingSystems
     {
+        public static OperatingSystem Windows81 = new OperatingSystem() { UserAgentVersion = "Windows NT 6.3", PrettyVersion = "Windows 8.1", LatestCLRVersion = CLRVersions.NET45Full };
         public static OperatingSystem Windows8 = new OperatingSystem() { UserAgentVersion = "Windows NT 6.2", PrettyVersion = "Windows 8", LatestCLRVersion = CLRVersions.NET45Full };
         public static OperatingSystem Windows7 = new OperatingSystem() { UserAgentVersion = "Windows NT 6.1", PrettyVersion = "Windows 7", LatestCLRVersion = CLRVersions.NET45Full };
         public static OperatingSystem WindowsVista = new OperatingSystem() { UserAgentVersion = "Windows NT 6.0", PrettyVersion = "Windows Vista", LatestCLRVersion = CLRVersions.NET45Full };
@@ -26,6 +27,7 @@
 
         public static List<OperatingSystem> OSVersions = new List<OperatingSystem>
 	{
+	    Windows81,
 	    Windows8,
 	    Windows7,
 	    WindowsVista,

--- a/SmallestTest/OperatingSystemVersionTests.cs
+++ b/SmallestTest/OperatingSystemVersionTests.cs
@@ -29,6 +29,17 @@
 	    Assert.AreEqual(Windows8OperatingSystem, actualOS);
 	}
 
+    [TestMethod]
+    public void CheckWindows81()
+    {
+        var UserAgent = "Windows NT 6.3";
+        var Windows8OperatingSystem = OperatingSystems.Windows81;
+
+        var actualOS = OperatingSystems.GetOperatingSystem(UserAgent);
+
+        Assert.AreEqual(Windows8OperatingSystem, actualOS);
+    }
+
 	[TestMethod]
 	public void CheckWindows7()
 	{


### PR DESCRIPTION
When I go to smallestdotnet.com on my IE running on my Windows 8.1 box it
says: "I can't see what browser you have."
Turns out it's because the code is testing for Win8 but not 8.1
This commit rectifies that.