### PR TITLE
Better handling of unknown release keys in registry

### DIFF
--- a/CheckForDotNet45/Program.cs
+++ b/CheckForDotNet45/Program.cs
@@ -1,76 +1,119 @@
-﻿using Microsoft.Win32;
-
+﻿// -----------------------------------------------------------------------
+// <copyright file="program.cs" company="Scott Hanselman, Michael Sarchet and Friends">
+//     Copyright © Scott Hanselman, Michael Sarchet and Friends 2012. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
 namespace CheckForDotNet45
 {
     using System;
     using System.Diagnostics;
 
-    class Program
+    using Microsoft.Win32;
+
+    /// <summary>
+    /// Class containing all application logic
+    /// </summary>
+    public class Program
     {
-        private const string Site = "http://smallestdotnet.com/?realversion={0}";
-        private const string ReleaseKeyParameter = "&releaseKey={1}";
+        #region Fields
 
-        static void Main(string[] args)
+        /// <summary>Site URL with release key parameter</summary>
+        private const string SiteWithReleaseKey = "http://smallestdotnet.com/?releaseKey={0}";
+
+        /// <summary>Site URL with version parameter</summary>
+        private const string SiteWithVersion = "http://smallestdotnet.com/?realversion={0}";
+
+        #endregion Fields
+
+        #region Methods
+
+        /// <summary>
+        /// Main entry point for program.
+        /// </summary>
+        public static void Main()
         {
-            Console.Write("Checking .NET version...");
-
-            int releaseKey = 0;
-            bool exact = true;
-            string version = IsNet45OrNewer() 
-                ? Get45or451FromRegistry(out exact, out releaseKey) 
-                : Environment.Version.ToString();
             try
             {
-                string url = exact
-                    ? string.Format(Site, version)
-                    : string.Format(Site + ReleaseKeyParameter, version, releaseKey);
-                Process.Start(url);
+                Console.Write("Checking .NET version...");
+
+                int releaseKey = 0;
+                string version = null;
+                if (IsNet45OrNewer())
+                {
+                    releaseKey = GetDotnetReleaseKeyFromRegistry();
+                }
+                else
+                {
+                    version = Environment.Version.ToString();
+                }
+
+                string url = string.IsNullOrEmpty(version)
+                        ? string.Format(SiteWithReleaseKey, releaseKey)
+                        : string.Format(SiteWithVersion, version);
+                try
+                {
+                    Process.Start(url);
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("\nApplication was unable to launch browser to go to {0}", url);
+                    if (version != null)
+                    {
+                        Console.WriteLine("Your current .NET version is: " + version);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Please browse to the URL to get version information.");
+                    }
+
+                    Console.ReadLine(); // Pause
+                }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Console.WriteLine("\nApplication was unable to launch browser");
-                Console.WriteLine("Your current .NET version is: " + version);
-                Console.ReadLine(); //Pause
+                Console.WriteLine("An error occurred:");
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(ex.ToString());
+                Console.ResetColor();
+                Console.WriteLine("Please log an issue including the error information at https://github.com/shanselman/SmallestDotNet/issues/");
+                Console.ReadLine(); // Pause
             }
         }
 
-        public static bool IsNet45OrNewer()
+        /// <summary>
+        /// Gets the .Net release key from registry "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\".
+        /// </summary>
+        /// <returns>Release key or -1 if not found</returns>
+        private static int GetDotnetReleaseKeyFromRegistry()
+        {
+            int releaseKey = -1;
+
+            // Based on http://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx#net_d
+            using (
+                RegistryKey ndpKey =
+                    RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
+                        .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
+            {
+                if (ndpKey != null)
+                {
+                    object releaseKeyValue = ndpKey.GetValue("Release") ?? "-1";
+                    int.TryParse(releaseKeyValue.ToString(), out releaseKey);
+                }
+
+                return releaseKey;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether we have .net 4.5 or newer.
+        /// </summary>
+        /// <returns>true if we have .net 4.5 or newer</returns>
+        private static bool IsNet45OrNewer()
         {
             // Class "ReflectionContext" exists in .NET 4.5 .
             return Type.GetType("System.Reflection.ReflectionContext", false) != null;
         }
 
-        //Improved but based on http://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx#net_d
-        private static string Get45or451FromRegistry(out bool exact, out int releaseKey)
-        {
-            using (RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
-               RegistryView.Registry32).OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
-            {
-                exact = true;
-                releaseKey = (int)ndpKey.GetValue("Release");
-                {
-                    if (releaseKey == 378389)
-                        return "4.5";
-
-                    if (releaseKey == 378758 || releaseKey == 378675)
-                        return "4.5.1";
-
-                    if (releaseKey == 379893)
-                        return "4.5.2";
-
-                    if (releaseKey == 381029)
-                        return "4.6 Preview";
-
-                    if (releaseKey > 381029)
-                    {
-                        exact = false;
-                        return "4.6 or greater";
-                    }
-                }
-            }
-
-            exact = false;
-            return "4.5 or greater";
-        }
+        #endregion Methods
     }
 }

--- a/CheckForDotNet45/Program.cs
+++ b/CheckForDotNet45/Program.cs
@@ -64,6 +64,7 @@ namespace CheckForDotNet45
                     if (releaseKey > 381029)
                     {
                         exact = false;
+                        return "4.6 or greater";
                     }
                 }
             }

--- a/SmallestDotNet/Default.aspx
+++ b/SmallestDotNet/Default.aspx
@@ -149,7 +149,7 @@
     <script type="text/javascript">
         $(function () {
             $('.result-header').hide();
-            if (document.location.search.indexOf('realversion') > -1) {
+            if (document.location.search.indexOf('releaseKey') > -1 || document.location.search.indexOf('realversion') > -1) {
                 $('#header-statement').text('We Found .NET!');
                 $('.result-header').fadeIn(1000);
                 return;

--- a/SmallestDotNet/Default.aspx.cs
+++ b/SmallestDotNet/Default.aspx.cs
@@ -7,21 +7,21 @@ public partial class _Default : System.Web.UI.Page
 {
     protected void Page_Load(object sender, EventArgs e)
     {
-        string userAgentText;
+        string realVersion = null;
+        int releaseKey = 0;
         bool runFromChecker = false;
-        userAgent.Text = HttpUtility.HtmlEncode(Request.UserAgent);
+        string userAgentText = this.Request.UserAgent ?? string.Empty;
+        userAgent.Text = HttpUtility.HtmlEncode(userAgentText);
 
         if (Request.QueryString["realversion"] != null)
         {
-            userAgentText = this.Request.QueryString["realversion"];
+            realVersion = this.Request.QueryString["realversion"];
+            int.TryParse(this.Request.QueryString["releaseKey"], out releaseKey);
             runFromChecker = true;
         }
-        else
-        {
-            userAgentText = this.Request.UserAgent;
-        }
 
-        UpdateInformationResponse response = Helpers.GetUpdateInformation(userAgentText, this.Request.Browser.ClrVersion);
+
+        UpdateInformationResponse response = Helpers.GetUpdateInformation(userAgentText, realVersion, releaseKey);
 
         userResult.Text = response.Text;
         developerOnline.Text = String.Format(@"If your users have internet connectivity, the .NET Framework is only between {1} and {2} megs. Why such a wide range? Well, it depends on if they already have some version of .NET.

--- a/SmallestDotNet/Default.aspx.cs
+++ b/SmallestDotNet/Default.aspx.cs
@@ -13,7 +13,7 @@ public partial class _Default : System.Web.UI.Page
         string userAgentText = this.Request.UserAgent ?? string.Empty;
         userAgent.Text = HttpUtility.HtmlEncode(userAgentText);
 
-        if (Request.QueryString["realversion"] != null)
+        if (Request.QueryString["realversion"] != null || this.Request.QueryString["releaseKey"] != null)
         {
             realVersion = this.Request.QueryString["realversion"];
             int.TryParse(this.Request.QueryString["releaseKey"], out releaseKey);

--- a/SmallestDotNet/VersionCheck.ashx.cs
+++ b/SmallestDotNet/VersionCheck.ashx.cs
@@ -16,35 +16,11 @@ namespace SmallestDotNet
             if (context.Request.RequestType == "GET")
             {
                 var userAgent = context.Request["userAgent"];
-                var netVersions = userAgent.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries).Where(s => s.Contains(".NET CLR"));
-                Version version = GetNetVersion(netVersions);
                 context.Response.ContentType = "text/plain";
-                context.Response.Write(Helpers.GetUpdateInformation(userAgent, version).Text);
+                context.Response.Write(Helpers.GetUpdateInformation(userAgent).Text);
             }
         }
 
-
-        private Version GetNetVersion(IEnumerable<string> versions)
-        {
-            //I think were only looking for CLR versions
-            if (versions.Any())
-            {
-                var versionNumbers = new List<string>();
-                versions.ToList().ForEach(v =>
-                {
-                    var number = v.Split(new string[] { ".NET CLR" }, StringSplitOptions.None)[1].Trim();
-                    versionNumbers.Add(number);
-
-                });
-
-                versionNumbers = versionNumbers.OrderByDescending(x => x).ToList();
-                Version ret = Version.Parse(versionNumbers.First());
-
-                return ret;
-            }
-
-            return null;
-        }
         public bool IsReusable
         {
             get

--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -18,7 +18,7 @@ public static class Constants
 
     public const string EarlyAdopter = "You're totally up to date! You've got a <strong>{0}</strong> on your machine. ";
     public const string CheckerFound = "The .Net Checker application determined that you have <strong>{0}</strong> on your machine. ";
-    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please log an issue using the link at the bottom of the page including this information: <strong>releaseKey={1}</strong>";
+    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please <a href=\"https://github.com/shanselman/SmallestDotNet/issues/\">log an issue</a> including this information.: <strong>releaseKey={1}</strong>";
 
     public static readonly Dictionary<string, string> OldWindows = new Dictionary<string, string>
     {

--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -18,7 +18,7 @@ public static class Constants
 
     public const string EarlyAdopter = "You're totally up to date! You've got a <strong>{0}</strong> on your machine. ";
     public const string CheckerFound = "The .Net Checker application determined that you have <strong>{0}</strong> on your machine. ";
-    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please <a href=\"https://github.com/shanselman/SmallestDotNet/issues/\">log an issue</a> including this information.: <strong>releaseKey={1}</strong>";
+    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please <a href=\"https://github.com/shanselman/SmallestDotNet/issues/\">log an issue</a> including this information: <strong>releaseKey={1}</strong>";
 
     public static readonly Dictionary<string, string> OldWindows = new Dictionary<string, string>
     {

--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -18,7 +18,7 @@ public static class Constants
 
     public const string EarlyAdopter = "You're totally up to date! You've got a <strong>{0}</strong> on your machine. ";
     public const string CheckerFound = "The .Net Checker application determined that you have <strong>{0}</strong> on your machine. ";
-    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please <a href=\"https://github.com/shanselman/SmallestDotNet/issues/\">log an issue</a> including this information: <strong>releaseKey={1}</strong>";
+    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please <a href=\"https://github.com/shanselman/SmallestDotNet/issues/\">log an issue</a> including this information: <strong>releaseKey={1}</strong> so we can get it exact in the future.";
 
     public static readonly Dictionary<string, string> OldWindows = new Dictionary<string, string>
     {
@@ -26,6 +26,19 @@ public static class Constants
         {"Windows 95", "Windows 95"},
         {"Windows 98", "Windows 98"}
     };
+
+    /// <summary>
+    /// The .Net versions (4.5 and above) keyed by the registry key value.
+    /// </summary>
+    public static readonly SortedDictionary<int, string> ReleaseVersions = new SortedDictionary<int, string>
+                           {
+                               { int.MinValue, "4.5" },
+                               { 378389, "4.5" },
+                               { 378675, "4.5.1" },
+                               { 378758, "4.5.1" },
+                               { 379893, "4.5.2" },
+                               { 381029, "4.6 Preview" },
+                           };
 
     public const string Windows8 = "Windows NT 6.2";
     public const string Windows81 = "Windows NT 6.3";

--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -17,6 +17,8 @@ public static class Constants
                            For you, it'll probably be <strong>around {0} megabytes total</strong>.";
 
     public const string EarlyAdopter = "You're totally up to date! You've got a <strong>{0}</strong> on your machine. ";
+    public const string CheckerFound = "The .Net Checker application determined that you have <strong>{0}</strong> on your machine. ";
+    public const string CheckerFoundNotExact = "The application was not able to determine the exact version you have. Please log an issue using the link at the bottom of the page including this information: <strong>releaseKey={1}</strong>";
 
     public static readonly Dictionary<string, string> OldWindows = new Dictionary<string, string>
     {

--- a/SmallestTest/VersionCheckTest.cs
+++ b/SmallestTest/VersionCheckTest.cs
@@ -65,19 +65,32 @@
             // Assert
             StringAssert.StartsWith(message, CheckerApplicationText);
             StringAssert.Contains(message, RealVersion);
-            Assert.IsFalse(message.Contains(UnableToDetermineText), "The '...not able to determine the exact version...' message should NOT appear if releaseKey=0");
+            Assert.IsFalse(message.Contains(UnableToDetermineText), "The '...not able to determine the exact version...' message should NOT appear if realVersion is present and releaseKey=0");
    
-            // Arrange
-            releaseKey = 9999;
+            foreach (var releaseVersion in Constants.ReleaseVersions)
+            {
+                // Arrange
+                releaseKey = releaseVersion.Key;
 
-            // Act
-            message = Helpers.GetUpdateInformation(UserAgent, RealVersion, releaseKey).Text;
+                // Act
+                message = Helpers.GetUpdateInformation(UserAgent, null, releaseKey).Text;
 
-            // Assert
-            StringAssert.StartsWith(message, CheckerApplicationText);
-            StringAssert.Contains(message, RealVersion);
-            StringAssert.Contains(message, UnableToDetermineText, "The '...not able to determine the exact version...' message SHOULD appear if releaseKey>0");
-            StringAssert.Contains(message, releaseKey.ToString(CultureInfo.InvariantCulture));
+                // Assert
+                StringAssert.StartsWith(message, CheckerApplicationText);
+                StringAssert.Contains(message, releaseVersion.Value);
+                Assert.IsFalse(message.Contains(UnableToDetermineText), "The '...not able to determine the exact version...' message should NOT appear if releaseKey is contained in Constants.ReleaseVersions");
+
+                // Arrange
+                releaseKey = releaseVersion.Key + 1;
+
+                // Act
+                message = Helpers.GetUpdateInformation(UserAgent, null, releaseKey).Text;
+
+                // Assert
+                StringAssert.StartsWith(message, CheckerApplicationText);
+                StringAssert.Contains(message, releaseVersion.Value + " or greater");
+                StringAssert.Contains(message, UnableToDetermineText, "The '...not able to determine the exact version...' message SHOULD appear if releaseKey is not contained in Constants.ReleaseVersions");
+            }
         }
     }
 }

--- a/SmallestTest/VersionCheckTest.cs
+++ b/SmallestTest/VersionCheckTest.cs
@@ -1,5 +1,7 @@
 ﻿namespace SmallestTest
 {
+    using System.Globalization;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Collections.Generic;
@@ -42,6 +44,40 @@
             var userAgent = "Windows NT 6.2";
 
             Assert.IsTrue(Helpers.HasWindows8(userAgent), "Windows 8");
+            userAgent = "Windows NT 6.3";
+
+            Assert.IsTrue(Helpers.HasWindows8(userAgent), "Windows 8.1");
+        }
+
+        [TestMethod]
+        public void CheckRealVersion()
+        {
+            // Arrange
+            const string UserAgent = ".NET Version 1.0";
+            const string RealVersion = "4.5.1";
+            const string CheckerApplicationText = "The .Net Checker application determined that you have";
+            const string UnableToDetermineText = "The application was not able to determine the exact version you have.";
+            var releaseKey = 0;
+
+            // Act
+            string message = Helpers.GetUpdateInformation(UserAgent, RealVersion, releaseKey).Text;
+
+            // Assert
+            StringAssert.StartsWith(message, CheckerApplicationText);
+            StringAssert.Contains(message, RealVersion);
+            Assert.IsFalse(message.Contains(UnableToDetermineText), "The '...not able to determine the exact version...' message should NOT appear if releaseKey=0");
+   
+            // Arrange
+            releaseKey = 9999;
+
+            // Act
+            message = Helpers.GetUpdateInformation(UserAgent, RealVersion, releaseKey).Text;
+
+            // Assert
+            StringAssert.StartsWith(message, CheckerApplicationText);
+            StringAssert.Contains(message, RealVersion);
+            StringAssert.Contains(message, UnableToDetermineText, "The '...not able to determine the exact version...' message SHOULD appear if releaseKey>0");
+            StringAssert.Contains(message, releaseKey.ToString(CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
This commit has the .Net Application checker return the releaseKey from
the registry if it's not a known key tied to a .Net version. The website
then uses this information to tell the user that it can't find the exact
version and suggests they log an issue with the given release key.
This is in response to issue #41: Handle unknown releases better.