### PR TITLE
Add .NET 4.6.2 final detection

### DIFF
--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -52,6 +52,8 @@ public static class Constants
                                { 394747, "4.6.2 Preview" },
                                { 394748, "4.6.2 Preview" },
                                { 394757, "4.6.2 Preview" },
+                               { 394802, "4.6.2" },
+                               { 394806, "4.6.2" },
                            };
 
     public const string Windows8 = "Windows NT 6.2";


### PR DESCRIPTION
Existing version detected the 4.6.2 Preview, added support for the released version as well.
Reviewed and completed based on https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx