### PR TITLE
Fix typo in releaseKey number

### DIFF
--- a/SmallestDotNetLib/Constants.cs
+++ b/SmallestDotNetLib/Constants.cs
@@ -59,7 +59,7 @@ public static class Constants
                                { 461308, "4.7.1" },
                                { 461310, "4.7.1" },
                                { 461808, "4.7.2" },
-                               { 491814, "4.7.2" },
+                               { 461814, "4.7.2" },
                            };
 
     public const string Windows8 = "Windows NT 6.2";


### PR DESCRIPTION
Fixing a typo in releaseKey number.
Previous commits added 4**9**1814 as 4.7.2, but this should have been 4**6**1814.

This version number can be confirmed by checking the list at https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-viewing-the-registry-net-framework-45-and-later

This fixes issue #103 